### PR TITLE
ENH: Enable doxygen structs to be utilized in the breathelink

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,11 @@
 breathelink
 ===========
 
-A sphinx extension that creates a new directive to simultaneously call the
-breathe_ `doxygenclass` directive and a doxylink_ role to import doxygen class
-documentation and create a link to the full class documentation.  The new
-directive `breathelink` also creates an index entry.
+A sphinx extension that creates new directives to simultaneously call the
+breathe_ `doxygenclass` or `doxygenstruct` directive and a doxylink_ role to import doxygen
+documentation and create a link to the full documentation. The new
+directives `breathelink` and `breathelinkstruct` also create an index entry.
+The Directive `breathelink` is used for the `doxygenclass` while the `breathelinkstruct` is used for the `doxygenstruct`.
 
 .. _breathe: https://github.com/michaeljones/breathe
 .. _doxylink: https://bitbucket.org/birkenfeld/sphinx-contrib/

--- a/breathelink.py
+++ b/breathelink.py
@@ -28,7 +28,10 @@ class BreathelinkDirective(Directive):
         if 'breathe' in self.options:
             breathe_directive_name = self.options['breathe']
         else:
-            breathe_directive_name = config.breathelink_default_breathe_directive
+            if 'breathelinkstruct' in self.name:
+                breathe_directive_name = config.breathelink_struct_breathe_directive
+            else:
+                breathe_directive_name = config.breathelink_default_breathe_directive
         if 'doxylink' in self.options:
             doxylink_role_name = self.options['doxylink']
         else:
@@ -73,11 +76,14 @@ def setup(app):
         'doxygenclass', True)
     app.add_config_value('breathelink_default_doxylink_role',
         'doxylink', True)
+    app.add_config_value('breathelink_struct_breathe_directive',
+        'doxygenstruct', True)
 
     app.add_directive('breathelink', BreathelinkDirective)
+    app.add_directive('breathelinkstruct', BreathelinkDirective)
 
     return {
-        'version': '0.1',
+        'version': '0.2',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }


### PR DESCRIPTION
Currently, only doxygen classes are enabled which throws warnings for ITK Struct's referenced in the ITKExamples repository. This will define a new Directive with the name `breathelinkstruct`, that will link a `doxygenstruct` instead of a `doxygenclass`. Thus, in the method `run()` when the Directive is processed, we define it to be a struct if the Directive's name is `breathelinkstruct`.

Overall, this will handle only a handful of structs referenced in the ITKExamples repository, but nevertheless it will grant insight into some of the commonly used structs ITK has to offer.  I've tried building ITKExamples with the new directive on my local computer and the warnings have been resolved with no new errors/warnings introduced. I will be creating a robust PR soon containing all my changes to get a clean documentation build for ITKExamples.

Lastly, the version for the repository was bumped to `0.2` and the `README` was updated.